### PR TITLE
修复解析问题

### DIFF
--- a/where2go/utils/waypoints/waypoint.py
+++ b/where2go/utils/waypoints/waypoint.py
@@ -82,4 +82,4 @@ color : int | str
         return f"xaero-waypoint:{self.name}:{self.title}:{':'.join(map(str,self.pos))}:{formatting_codes.index(self.color)}:false:0:{dimensions_map[self.dimension]}"
     
     def get_xaero_waypoint_add(self):
-        return f"xaero_waypoint_add:{self.name}:{self.title}:{':'.join(map(str,self.pos))}:{formatting_codes.index(self.color)}:false:0:Internal_{self.dimension}_waypoints"
+        return f"xaero_waypoint:{self.name}:{self.title}:{':'.join(map(str,self.pos))}:{formatting_codes.index(self.color)}:false:0:Internal_{self.dimension}_waypoints"


### PR DESCRIPTION
在添加路径点命令中
xaero_waypoint_add 的添加命令在高版本和低版本的解析兼容性堪忧，无论是最新的1.20.1版本，还是两年前的1.8.9都无法解析 xaero_waypoint_add ，这貌似是xaero作者在某些版本中添加的命令，但无法做到全版本兼容

修改为 xaero_waypoint 可以很好的解决这个问题，证据如下
![4167fc669494b3b3a6365e4efb50c9d9](https://github.com/user-attachments/assets/e26ae27b-a0a2-4971-9e64-a03a065976ee)
我已经在1.20.1和1.8.9双版本测试，实测xaero_waypoint前缀会比添加 add 的版本解析兼容性更好